### PR TITLE
Human readable uptime by Hugoo

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "influx": "^5.8.0",
     "lodash": "^4.17.21",
     "moment": "^2.29.1",
+    "moment-duration-format": "^2.3.2",
     "mustache": "^4.1.0",
     "node-fetch": "^2.6.1",
     "pg": "^8.5.1",

--- a/src/commands/info.js
+++ b/src/commands/info.js
@@ -30,7 +30,7 @@ module.exports = class Info extends Command {
         + `**:computer: ${this.client.user.username} ${_('words.version')}** ${this.client.pkg.version}\n`
 
         + `**:clock: ${_('words.uptime')}**: ${
-          process.uptime() ? _.toDurationFormat(process.uptime()) : '???'}\n`
+          this.client.uptime ? _.toDurationFormat(this.client.uptime) : '???'}\n`
 
         + `**:gear: ${_('words.mem_usage')}**: ${(process.memoryUsage().heapUsed / 1000000).toFixed(2)} MB\n`
 

--- a/src/commands/info.js
+++ b/src/commands/info.js
@@ -30,7 +30,7 @@ module.exports = class Info extends Command {
         + `**:computer: ${this.client.user.username} ${_('words.version')}** ${this.client.pkg.version}\n`
 
         + `**:clock: ${_('words.uptime')}**: ${
-          process.uptime() ? Util.toHHMMSS(process.uptime().toString()) : '???'}\n`
+          process.uptime() ? _.toDurationFormat(process.uptime()) : '???'}\n`
 
         + `**:gear: ${_('words.mem_usage')}**: ${(process.memoryUsage().heapUsed / 1000000).toFixed(2)} MB\n`
 

--- a/src/localehandler.js
+++ b/src/localehandler.js
@@ -4,6 +4,7 @@ const path = require('path');
 const reload = require('require-reload')(require);
 const lodash = require('lodash');
 const moment = require('moment');
+require('moment-duration-format');
 
 class LocaleHandler {
   constructor(client, cPath) {
@@ -116,6 +117,35 @@ class LocaleHandler {
 
     _.moment = (...args) =>
       moment(...args).locale((locale || this.config.sourceLocale).replace('_', '-'));
+
+    /**
+     * @example 514279423 equals "5 days, 22 hours, 51 minutes and 19 seconds"
+     * @author Hugo Vidal <hugo.vidal.ferre@gmail.com>
+     */
+    _.toDurationFormat = number => {
+      moment.updateLocale('en', {
+        durationLabelsStandard: {
+          s: _('time.second'),
+          ss: _('time.seconds'),
+          m: _('time.minute'),
+          mm: _('time.minutes'),
+          h: _('time.hour'),
+          hh: _('time.hours'),
+          d: _('time.day'),
+          dd: _('time.days'),
+          w: _('time.week'),
+          ww: _('time.weeks'),
+          M: _('time.month'),
+          MM: _('time.months'),
+          y: _('time.year'),
+          yy: _('time.years'),
+        },
+      });
+
+      return moment
+        .duration(number)
+        .format(`y __, M __, w __, d __, h __, m __ [${_('words.and')}] s __`);
+    };
 
     _.dateJS = (date, query) => {
       const countryCodeMap = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1190,6 +1190,11 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
+moment-duration-format@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/moment-duration-format/-/moment-duration-format-2.3.2.tgz#5fa2b19b941b8d277122ff3f87a12895ec0d6212"
+  integrity sha512-cBMXjSW+fjOb4tyaVHuaVE/A5TqkukDWiOfxxAjY+PEqmmBQlLwn+8OzwPiG3brouXKY5Un4pBjAeB6UToXHaQ==
+
 moment-timezone@^0.5.31, moment-timezone@^0.5.x:
   version "0.5.31"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.31.tgz#9c40d8c5026f0c7ab46eda3d63e49c155148de05"


### PR DESCRIPTION
[Update] **Human readable uptime** by Hugoo

Requires a new package:
- `moment-duration-format@^2.3.2`

This update changes this:
![image](https://user-images.githubusercontent.com/69076992/114425838-be5db780-9bb9-11eb-99ec-f2800df6b846.png)
to this:
![image](https://user-images.githubusercontent.com/69076992/114425881-c7e71f80-9bb9-11eb-8844-7338ed48f89c.png)

Another examples:
![image](https://user-images.githubusercontent.com/69076992/114426286-34fab500-9bba-11eb-9c0a-c95a41488c24.png)
![image](https://user-images.githubusercontent.com/69076992/114426354-49d74880-9bba-11eb-8abc-ec06a4e97bfa.png)
![image](https://user-images.githubusercontent.com/69076992/114426263-2f04d400-9bba-11eb-9919-f5d2f841b89d.png)

These examples I have been able to do by changing this to a number:
![image](https://user-images.githubusercontent.com/69076992/114427998-f49c3680-9bbb-11eb-9f75-9d069a57ab12.png)

