### PR TITLE
Human readable uptime V2 by Hugoo

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "influx": "^5.8.0",
     "lodash": "^4.17.21",
     "moment": "^2.29.1",
+    "moment-duration-format": "^2.3.2",
     "mustache": "^4.1.0",
     "node-fetch": "^2.6.1",
     "pg": "^8.5.1",

--- a/src/commands/info.js
+++ b/src/commands/info.js
@@ -30,7 +30,7 @@ module.exports = class Info extends Command {
         + `**:computer: ${this.client.user.username} ${_('words.version')}** ${this.client.pkg.version}\n`
 
         + `**:clock: ${_('words.uptime')}**: ${
-          process.uptime() ? _.toDurationFormat(process.uptime()) : '???'}\n`
+          this.client.uptime ? _.toDurationFormat(this.client.uptime) : '???'}\n`
 
         + `**:gear: ${_('words.mem_usage')}**: ${(process.memoryUsage().heapUsed / 1000000).toFixed(2)} MB\n`
 

--- a/src/commands/info.js
+++ b/src/commands/info.js
@@ -30,7 +30,7 @@ module.exports = class Info extends Command {
         + `**:computer: ${this.client.user.username} ${_('words.version')}** ${this.client.pkg.version}\n`
 
         + `**:clock: ${_('words.uptime')}**: ${
-          process.uptime() ? Util.toHHMMSS(process.uptime().toString()) : '???'}\n`
+          process.uptime() ? _.toDurationFormat(process.uptime()) : '???'}\n`
 
         + `**:gear: ${_('words.mem_usage')}**: ${(process.memoryUsage().heapUsed / 1000000).toFixed(2)} MB\n`
 

--- a/src/localehandler.js
+++ b/src/localehandler.js
@@ -4,6 +4,7 @@ const path = require('path');
 const reload = require('require-reload')(require);
 const lodash = require('lodash');
 const moment = require('moment');
+require('moment-duration-format');
 
 class LocaleHandler {
   constructor(client, cPath) {
@@ -116,6 +117,35 @@ class LocaleHandler {
 
     _.moment = (...args) =>
       moment(...args).locale((locale || this.config.sourceLocale).replace('_', '-'));
+
+    /**
+     * @example 514279423 equals "5 days, 22 hours, 51 minutes and 19 seconds"
+     * @author Hugo Vidal <hugo.vidal.ferre@gmail.com>
+     */
+    _.toDurationFormat = number => {
+      moment.updateLocale('en', {
+        durationLabelsStandard: {
+          s: _('time.second'),
+          ss: _('time.seconds'),
+          m: _('time.minute'),
+          mm: _('time.minutes'),
+          h: _('time.hour'),
+          hh: _('time.hours'),
+          d: _('time.day'),
+          dd: _('time.days'),
+          w: _('time.week'),
+          ww: _('time.weeks'),
+          M: _('time.month'),
+          MM: _('time.months'),
+          y: _('time.year'),
+          yy: _('time.years'),
+        },
+      });
+
+      return moment
+        .duration(number)
+        .format(`y __, M __, w __, d __, h __, m __ [${_('words.and')}] s __`);
+    };
 
     _.dateJS = (date, query) => {
       const countryCodeMap = {

--- a/src/localehandler.js
+++ b/src/localehandler.js
@@ -124,7 +124,7 @@ class LocaleHandler {
      */
     _.toDurationFormat = number => {
       return moment
-        .duration(67223453239)
+        .duration(number)
         .format(`y [y], M [M], w [w], d [d], h [h], m [m] [${_('words.and')}] s [s]`);
     };
 

--- a/src/localehandler.js
+++ b/src/localehandler.js
@@ -123,28 +123,9 @@ class LocaleHandler {
      * @author Hugo Vidal <hugo.vidal.ferre@gmail.com>
      */
     _.toDurationFormat = number => {
-      moment.updateLocale('en', {
-        durationLabelsStandard: {
-          s: _('time.second'),
-          ss: _('time.seconds'),
-          m: _('time.minute'),
-          mm: _('time.minutes'),
-          h: _('time.hour'),
-          hh: _('time.hours'),
-          d: _('time.day'),
-          dd: _('time.days'),
-          w: _('time.week'),
-          ww: _('time.weeks'),
-          M: _('time.month'),
-          MM: _('time.months'),
-          y: _('time.year'),
-          yy: _('time.years'),
-        },
-      });
-
       return moment
-        .duration(number)
-        .format(`y __, M __, w __, d __, h __, m __ [${_('words.and')}] s __`);
+        .duration(67223453239)
+        .format(`y [y], M [M], w [w], d [d], h [h], m [m] [${_('words.and')}] s [s]`);
     };
 
     _.dateJS = (date, query) => {

--- a/src/localehandler.js
+++ b/src/localehandler.js
@@ -119,7 +119,7 @@ class LocaleHandler {
       moment(...args).locale((locale || this.config.sourceLocale).replace('_', '-'));
 
     /**
-     * @example 514279423 equals "5 days, 22 hours, 51 minutes and 19 seconds"
+     * @example 514279423 equals "5 d, 22 h, 51 m and 19 s"
      * @author Hugo Vidal <hugo.vidal.ferre@gmail.com>
      */
     _.toDurationFormat = number => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1190,6 +1190,11 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
+moment-duration-format@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/moment-duration-format/-/moment-duration-format-2.3.2.tgz#5fa2b19b941b8d277122ff3f87a12895ec0d6212"
+  integrity sha512-cBMXjSW+fjOb4tyaVHuaVE/A5TqkukDWiOfxxAjY+PEqmmBQlLwn+8OzwPiG3brouXKY5Un4pBjAeB6UToXHaQ==
+
 moment-timezone@^0.5.31, moment-timezone@^0.5.x:
   version "0.5.31"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.31.tgz#9c40d8c5026f0c7ab46eda3d63e49c155148de05"


### PR DESCRIPTION
[Update] **Human readable uptime V2** by Hugoo

Requires a new package:
- `moment-duration-format@^2.3.2`

This update changes this:
![image](https://user-images.githubusercontent.com/69076992/114425838-be5db780-9bb9-11eb-99ec-f2800df6b846.png)
to this:
![image](https://user-images.githubusercontent.com/69076992/114462463-5e7c0680-9be3-11eb-9f90-eaff2de35f77.png)

Another examples:
![image](https://user-images.githubusercontent.com/69076992/114462489-663bab00-9be3-11eb-974c-b9e0e81a8c22.png)
![image](https://user-images.githubusercontent.com/69076992/114462543-7b183e80-9be3-11eb-91bc-ea23e3b42f08.png)
![image](https://user-images.githubusercontent.com/69076992/114462591-8cf9e180-9be3-11eb-9084-4f9f664aa885.png)

These examples I have been able to do by changing this to a number:
![image](https://user-images.githubusercontent.com/69076992/114463131-52dd0f80-9be4-11eb-8b58-44ab85a8ced9.png)